### PR TITLE
Update Authorino volumeMounts to latest API

### DIFF
--- a/authorino.yaml
+++ b/authorino.yaml
@@ -10,15 +10,12 @@ spec:
     tls:
       enabled: false
   volumes:
-  - name: keycloak-cert
-    configMap:
-      name: keycloak-tls-cert-ext
+    items:
+    - name: keycloak-cert
+      mountPath: /etc/ssl/certs
+      configMaps:
+      - keycloak-tls-cert-ext
       items:
       - key: keycloak.crt
         path: keycloak.crt
-  volumeMounts:
-  - name: keycloak-cert
-    mountPath: /etc/ssl/certs/keycloak.crt
-    subPath: keycloak.crt
-    readOnly: true
   logLevel: debug


### PR DESCRIPTION
Uses the new API of the `Authorino` CR regarding definition of extra volume mounts, accordign to the latest version of https://github.com/Kuadrant/authorino-operator/pull/20.